### PR TITLE
Fixing Prototype pollution and DoS vulnerabilties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,8 +68,8 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "^4.6.0",
@@ -456,8 +456,8 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
         "follow-redirects": "^1.2.3",


### PR DESCRIPTION
You are vulnerable to  2 issues. 

PoC of Prototype pollution in your general case:

```
merge (target, source)

  foreach property of source

    if property exists and is an object on both the target and the source

      merge(target[property], source[property])

    else

      target[property] = source[property]
```

PoC of DoS:

```
require('axios').get(
  'https://upload.wikimedia.org/wikipedia/commons/f/fe/A_Different_Slant_on_Carina.jpg',
  { maxContentLength: 2000 }
)
  .then(d => console.log('done'))
  .catch(e => console.log(e.toString()))
```

Credits:
- CVE-2020-15366
- CVE-2019-10742